### PR TITLE
remove ropensci/git2r from Remotes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,6 +27,5 @@ Suggests:
 RoxygenNote: 5.0.1.9000
 Remotes:
     gaborcsardi/gh,
-    ropensci/git2r,
     hadley/dplyr
 VignetteBuilder: knitr


### PR DESCRIPTION
Since git2r updated on CRAN, using this will avoid a new install of git2r every time ropensci makes a minor tweak. It also allows me to install this on my machine :smiley_cat: 